### PR TITLE
Potential fix for code scanning alert no. 1: Missing regular expression anchor

### DIFF
--- a/internal/parser/third_party_parser.go
+++ b/internal/parser/third_party_parser.go
@@ -94,7 +94,7 @@ func (p *ThirdPartyIdParser) extractIMDBIDFromURL(href string) (string, error) {
 	logger := config.GetLogger()
 
 	// IMDB URLs are like: http://www.imdb.com/title/tt14261112/
-	re := regexp.MustCompile(`imdb\.com/title/(tt\d+)/?`)
+	re := regexp.MustCompile(`^(?:https?://)?(?:www\.)?imdb\.com/title/(tt\d+)/?`)
 	matches := re.FindStringSubmatch(href)
 	if len(matches) < 2 {
 		logger.Debug().Str("href", href).Msg("No IMDB ID found in URL")


### PR DESCRIPTION
Potential fix for [https://github.com/Belphemur/SuperSubtitles/security/code-scanning/1](https://github.com/Belphemur/SuperSubtitles/security/code-scanning/1)

In general, to fix this type of issue you should add appropriate anchors (`^` for start, `$` for end) and, when matching URLs, ensure the host and path are constrained so the regex cannot match arbitrary substrings embedded elsewhere in the URL. This prevents cases where an allowed pattern appears in a query parameter or fragment but the overall URL is not from the expected domain or path.

For this specific case in `internal/parser/third_party_parser.go`, the best minimal fix that does not change desired functionality is to anchor the regex to the start of the URL string, and retain the current flexibility regarding scheme and trailing slash. The existing comment says “IMDB URLs are like: http://www.imdb.com/title/tt14261112/”, so we should ensure we only match URLs whose beginning includes an IMDB host segment and the `/title/tt...` path. A safe, backward-compatible improvement is to add `^` at the start of the pattern and allow for optional protocol and `www.` while still requiring `imdb.com/title/...` at the beginning of the string. For example:

```go
re := regexp.MustCompile(`^(?:https?://)?(?:www\.)?imdb\.com/title/(tt\d+)/?`)
```

This preserves extraction of the `tt` identifier while preventing matches where `imdb.com/title/...` appears later in the URL (e.g., in a query string). Only line 97 in `extractIMDBIDFromURL` needs to change; no new imports or helper methods are required because `regexp` is already imported and used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
