### PR TITLE
Potential fix for code scanning alert no. 2: Missing regular expression anchor

### DIFF
--- a/internal/parser/third_party_parser.go
+++ b/internal/parser/third_party_parser.go
@@ -145,7 +145,7 @@ func (p *ThirdPartyIdParser) extractTVMazeIDFromURL(href string) (int, error) {
 	logger := config.GetLogger()
 
 	// TVMaze URLs are like: http://www.tvmaze.com/shows/60743
-	re := regexp.MustCompile(`tvmaze\.com/shows/(\d+)`)
+	re := regexp.MustCompile(`^https?://(?:www\.)?tvmaze\.com/shows/(\d+)`)
 	matches := re.FindStringSubmatch(href)
 	if len(matches) < 2 {
 		logger.Debug().Str("href", href).Msg("No TVMaze ID found in URL")


### PR DESCRIPTION
Potential fix for [https://github.com/Belphemur/SuperSubtitles/security/code-scanning/2](https://github.com/Belphemur/SuperSubtitles/security/code-scanning/2)

In general, to fix this class of problem you should either (a) parse the URL and verify the host and path explicitly, or (b) anchor the regular expression so it only matches at the intended location(s), typically the start of the string and/or after a known scheme/host prefix. Since this function already receives a raw URL string and uses `regexp.MustCompile`, the smallest, least invasive fix is to make the regex match only when the string actually represents a TVMaze show URL.

The current pattern is:

```go
re := regexp.MustCompile(`tvmaze\.com/shows/(\d+)`)
```

This can match anywhere in the URL. A simple fix is to anchor it with `^https?://` so it only matches URLs whose scheme is HTTP or HTTPS and whose host is `tvmaze.com` or `www.tvmaze.com`. For example:

```go
re := regexp.MustCompile(`^https?://(?:www\.)?tvmaze\.com/shows/(\d+)`)
```

This preserves the existing extraction logic (`FindStringSubmatch(href)` and `matches[1]` as the ID) while preventing matches where `tvmaze.com/shows/...` appears later in the URL. No new imports or helper methods are needed, and all edits are confined to `internal/parser/third_party_parser.go`, specifically line 148 where the regex is defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
